### PR TITLE
Raise log retention time period for SOC2 purposes.

### DIFF
--- a/modules/aws/ecs/cloudwatch_logs.tf
+++ b/modules/aws/ecs/cloudwatch_logs.tf
@@ -1,6 +1,6 @@
 resource "aws_cloudwatch_log_group" "main" {
   name              = "/aws/ecs/${local.prefix}"
-  retention_in_days = local.common_tags["env"] == "prd" ? 0 : 30
+  retention_in_days = local.common_tags["env"] == "prd" ? 0 : 365
   kms_key_id        = var.kms_arn
 
   tags = local.common_tags


### PR DESCRIPTION
The SOC2 process seems to like a year of retention, which seems reasonable.